### PR TITLE
fix: plugin root

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "metadata": {
     "description": "Skills, agents, and plugins for AI coding agents working with Azure SDKs and Microsoft AI Foundry",
     "version": "1.0.0",
-    "pluginRoot": "./.github/plugins"
+    "pluginRoot": "./"
   },
   "plugins": [
     {


### PR DESCRIPTION
To fix the skill install issue (https://github.com/microsoft/skills/issues/363)

The plugin root/source was changed in (https://github.com/microsoft/skills/pull/148) and (https://github.com/microsoft/skills/pull/223), then has duplicated prefix `./.github/plugins`, thus the `skills` command failed to detect those skills under plugins.
This PR changes to `"pluginRoot": "./"` , which keeps `pluginRoot` for compatibility and uses `./` as no-op.