### PR TITLE
fix: clean up outdated content in microsoft-foundry plugin

### DIFF
--- a/.github/plugins/microsoft-foundry/.mcp.json
+++ b/.github/plugins/microsoft-foundry/.mcp.json
@@ -7,10 +7,6 @@
     "foundry-mcp": {
       "type": "http",
       "url": "https://mcp.ai.azure.com"
-    },
-    "microsoft-docs": {
-      "url": "https://learn.microsoft.com/api/mcp",
-      "type": "http"
     }
   }
 }

--- a/.github/plugins/microsoft-foundry/README.md
+++ b/.github/plugins/microsoft-foundry/README.md
@@ -5,12 +5,6 @@
 ## Install
 
 ```bash
-# Copilot CLI
-/plugin marketplace add microsoft/skills
-/plugin install microsoft-foundry@skills
-```
-
-```bash
 # npx
 npx skills add microsoft/skills --skill microsoft-foundry
 ```
@@ -25,7 +19,6 @@ The plugin bundles three MCP servers that activate automatically on install:
 |--------|---------|
 | **Azure MCP** | Manage Azure resources, deployments, and infrastructure from your editor. 40+ services. |
 | **Foundry MCP** | Foundry-native operations at `mcp.ai.azure.com` -- model catalog, agents, toolboxes, knowledge bases, evals. |
-| **Microsoft Docs** | Search Microsoft Learn in real-time so the agent always uses current Foundry/SDK patterns. |
 
 ### Skills
 
@@ -34,16 +27,6 @@ One orchestrator routes intent to ten language-agnostic sub-skills. Each sub-ski
 | Skill | What It Covers |
 |-------|---------------|
 | `microsoft-foundry` | **Orchestrator.** Maps user intent (build a hosted agent, curate a toolbox, ground on docs, set up evals, govern tools, personalize, orchestrate) onto the right sub-skill and the right discovery surface (Microsoft Docs MCP, Foundry MCP, `azd ai agent`, `az`). |
-| `foundry-projects-resources` | Provision Foundry resources and projects, configure project connections (key-auth, OAuth, managed identity, agent identity), standard vs private-network agent infrastructure, Azure auth via `DefaultAzureCredential` / `ManagedIdentityCredential`. |
-| `foundry-models` | Discover, deploy, and manage models. Preset vs customized deployments, capacity discovery across regions, quota management, PTU vs pay-as-you-go, RAI policy on model deployments. |
-| `foundry-hosted-agents` | Build, deploy, and manage hosted agents on the refreshed preview. Responses + Invocations protocols, `agent.yaml`, `azd ai agent`, ResponsesAgentServerHost / InvocationAgentServerHost, sessions, per-agent Microsoft Entra identity, dedicated endpoints. |
-| `foundry-toolboxes` | Curate intent-based Toolboxes (preview) — a single MCP-compatible endpoint bundling 9 tool types: MCP, Web Search, Azure AI Search, Code Interpreter, File Search, OpenAPI, A2A, Browser Automation, Computer Use. Build once, consume everywhere. |
-| `foundry-workflows` | Multi-agent orchestration. When to use a declarative workflow vs an A2A tool call vs the Connected Agents pattern, plus Microsoft Agent Framework workflow patterns. Author, visualize, and test. |
-| `foundry-iq-knowledge-bases` | Foundry IQ knowledge bases (preview) — multi-source, permission-aware grounding. Connect Blob/SharePoint/OneLake/web sources, use the agentic retrieval pipeline (decomposition + parallel search + reranking), expose via MCP to agents. |
-| `foundry-managed-skills` | SKILL.md as a Foundry-side resource (preview). Author behavioral guidelines once, store centrally via the Skills REST API, download into hosted agent containers as additional session instructions. Decouples policy from code. |
-| `foundry-memory` | Long-term memory stores (preview) for personalized agents across sessions. User profile vs chat summary memory, memory search tool vs memory store APIs, scoping, prompt-injection / memory-corruption risks, retention. |
-| `foundry-observability` | Trace, monitor, and evaluate hosted agents end-to-end. OpenTelemetry GenAI traces in App Insights via KQL, eval-trace correlation, `azd ai agent monitor`, dataset curation from production traces, built-in quality + safety/RAI evaluators, batch evals, regression detection. |
-| `foundry-governance` | Govern agent fleets at scale via the Foundry Control Plane and AI Gateway. Tool catalog visibility, MCP routing/policy, RBAC and agent identity, third-party tool risk, RAI policies on model deployments, transparency notes for production rollout. |
 
 ### Companion Skills
 
@@ -118,16 +101,6 @@ microsoft-foundry/
   README.md
   skills/
     microsoft-foundry/                # Orchestrator — routes intent to sub-skills
-    foundry-projects-resources/       # Resources, projects, connections, auth
-    foundry-models/                   # Deploy, capacity, quota, RAI policy
-    foundry-hosted-agents/            # Responses + Invocations, agent.yaml, azd
-    foundry-toolboxes/                # Intent-based toolboxes (9 tool types)
-    foundry-workflows/                # Workflow vs A2A vs Connected Agents
-    foundry-iq-knowledge-bases/       # Foundry IQ + agentic retrieval
-    foundry-managed-skills/           # SKILL.md as a Foundry resource
-    foundry-memory/                   # Long-term memory stores
-    foundry-observability/            # Tracing + KQL + evals + RAI evals
-    foundry-governance/               # Control Plane + AI Gateway + RBAC
 ```
 
 Skills are symlinked to canonical sources in the `azure-skills` plugin to maintain a single source of truth.

--- a/.github/plugins/microsoft-foundry/skills/foundry-governance
+++ b/.github/plugins/microsoft-foundry/skills/foundry-governance
@@ -1,1 +1,0 @@
-../../azure-skills/skills/foundry-governance

--- a/.github/plugins/microsoft-foundry/skills/foundry-hosted-agents
+++ b/.github/plugins/microsoft-foundry/skills/foundry-hosted-agents
@@ -1,1 +1,0 @@
-../../azure-skills/skills/foundry-hosted-agents

--- a/.github/plugins/microsoft-foundry/skills/foundry-iq-knowledge-bases
+++ b/.github/plugins/microsoft-foundry/skills/foundry-iq-knowledge-bases
@@ -1,1 +1,0 @@
-../../azure-skills/skills/foundry-iq-knowledge-bases

--- a/.github/plugins/microsoft-foundry/skills/foundry-managed-skills
+++ b/.github/plugins/microsoft-foundry/skills/foundry-managed-skills
@@ -1,1 +1,0 @@
-../../azure-skills/skills/foundry-managed-skills

--- a/.github/plugins/microsoft-foundry/skills/foundry-memory
+++ b/.github/plugins/microsoft-foundry/skills/foundry-memory
@@ -1,1 +1,0 @@
-../../azure-skills/skills/foundry-memory

--- a/.github/plugins/microsoft-foundry/skills/foundry-models
+++ b/.github/plugins/microsoft-foundry/skills/foundry-models
@@ -1,1 +1,0 @@
-../../azure-skills/skills/foundry-models

--- a/.github/plugins/microsoft-foundry/skills/foundry-observability
+++ b/.github/plugins/microsoft-foundry/skills/foundry-observability
@@ -1,1 +1,0 @@
-../../azure-skills/skills/foundry-observability

--- a/.github/plugins/microsoft-foundry/skills/foundry-projects-resources
+++ b/.github/plugins/microsoft-foundry/skills/foundry-projects-resources
@@ -1,1 +1,0 @@
-../../azure-skills/skills/foundry-projects-resources

--- a/.github/plugins/microsoft-foundry/skills/foundry-toolboxes
+++ b/.github/plugins/microsoft-foundry/skills/foundry-toolboxes
@@ -1,1 +1,0 @@
-../../azure-skills/skills/foundry-toolboxes

--- a/.github/plugins/microsoft-foundry/skills/foundry-workflows
+++ b/.github/plugins/microsoft-foundry/skills/foundry-workflows
@@ -1,1 +1,0 @@
-../../azure-skills/skills/foundry-workflows

--- a/README.md
+++ b/README.md
@@ -105,21 +105,11 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) and [G
 
 ### Foundry (Language-Agnostic)
 
-> 11 skills — Microsoft Foundry agent platform (preview), language-agnostic via `azd`, `az` CLI, and Foundry MCP
+> 1 skill — Microsoft Foundry agent platform (preview), language-agnostic via `azd`, `az` CLI, and Foundry MCP
 
 | Skill | Description |
 |-------|-------------|
 | [microsoft-foundry](.github/plugins/azure-skills/skills/microsoft-foundry/) | Router skill for the Foundry agent platform — maps user intent onto the right sub-skill and discovery surface (Microsoft Docs MCP, Foundry MCP, `azd ai agent`, `az` CLI). |
-| [foundry-projects-resources](.github/plugins/azure-skills/skills/foundry-projects-resources/) | Provision Foundry resources/projects, configure project connections (key, OAuth, managed identity, agent identity), and set up standard or private-network agent infrastructure. |
-| [foundry-models](.github/plugins/azure-skills/skills/foundry-models/) | Discover, deploy, and manage models on Foundry — preset/customized deployments, capacity discovery, quota management, PTU vs pay-as-you-go. |
-| [foundry-hosted-agents](.github/plugins/azure-skills/skills/foundry-hosted-agents/) | Build, deploy, and manage Foundry hosted agents — containerized agents exposing Responses or Invocations protocols, with per-agent Entra identity and dedicated endpoints. |
-| [foundry-toolboxes](.github/plugins/azure-skills/skills/foundry-toolboxes/) | Curate intent-based Foundry Toolboxes (preview) — a single MCP-compatible endpoint bundling tools (MCP, Web Search, AI Search, Code Interpreter, File Search, OpenAPI, A2A) for any agent to consume. |
-| [foundry-workflows](.github/plugins/azure-skills/skills/foundry-workflows/) | Build multi-agent workflows — declarative orchestration for handing off control between specialist agents, plus the Connected Agents pattern. |
-| [foundry-iq-knowledge-bases](.github/plugins/azure-skills/skills/foundry-iq-knowledge-bases/) | Build Foundry IQ knowledge bases (preview) — multi-source, permission-aware grounding for agents using the agentic retrieval pipeline. |
-| [foundry-managed-skills](.github/plugins/azure-skills/skills/foundry-managed-skills/) | Manage SKILL.md files as a Foundry-side resource (preview) — author behavioral guidelines once, store via the Skills REST API, load into hosted agent containers. |
-| [foundry-memory](.github/plugins/azure-skills/skills/foundry-memory/) | Build personalized Foundry agents with managed long-term memory (preview) — extract, consolidate, and retrieve user-specific context across sessions. |
-| [foundry-observability](.github/plugins/azure-skills/skills/foundry-observability/) | Trace, monitor, and evaluate Foundry hosted agents end-to-end — OpenTelemetry GenAI traces in App Insights, eval-trace correlation, batch evals, regression detection. |
-| [foundry-governance](.github/plugins/azure-skills/skills/foundry-governance/) | Govern Foundry agent fleets at scale — tool catalog visibility, AI Gateway MCP routing/policy, RBAC, agent identity, RAI policies on model deployments. |
 
 ---
 


### PR DESCRIPTION
3 changes in this PR:

1. Removed the ms-learn docs mcp, Azure MCP already exposes the MS Learn tools.
2. Deleted outdated skill references. These skills have been gone since at least March 2026.
3. Update microsoft-foundry plugin's readme to remove outdated content and non-working instructions.

These changes stop the microsoft-foundry plugin from giving incorrect information or instructions that no longer work.