### PR TITLE
feat(copilot-sdk): add OrcaRouter BYOK provider config

### DIFF
--- a/.github/skills/copilot-sdk/SKILL.md
+++ b/.github/skills/copilot-sdk/SKILL.md
@@ -536,6 +536,11 @@ provider: { type: "anthropic", baseUrl: "https://api.anthropic.com", apiKey: pro
 provider: { type: "openai", baseUrl: "http://localhost:11434/v1" }
 ```
 
+**OrcaRouter (OpenAI-compatible gateway):**
+```typescript
+provider: { type: "openai", baseUrl: "https://api.orcarouter.ai/v1", apiKey: process.env.ORCAROUTER_API_KEY }
+```
+
 ### Provider Config Reference
 
 | Field | Type | Description |


### PR DESCRIPTION
This adds [OrcaRouter](https://www.orcarouter.ai) as a first-class Bring Your Own Key provider option in the `copilot-sdk` skill, so Copilot SDK users can point the CLI at OrcaRouter without treating it as an anonymous custom base URL.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Because the Copilot SDK's BYOK mode already accepts an OpenAI-compatible `provider` config (the skill documents this for OpenAI, Azure AI Foundry, and Ollama), OrcaRouter plugs straight into that existing wiring as a named provider with a single `provider` block:

```typescript
provider: { type: "openai", baseUrl: "https://api.orcarouter.ai/v1", apiKey: process.env.ORCAROUTER_API_KEY }
```

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Verified locally against the live OrcaRouter endpoint (`GET https://api.orcarouter.ai/v1/chat/completions` returns 200 with a completion).

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
