### PR TITLE
Fix link to azure-monitor-query skill in azure-monitor-ingestion-java

### DIFF
--- a/.github/plugins/azure-sdk-java/skills/azure-monitor-ingestion-java/SKILL.md
+++ b/.github/plugins/azure-sdk-java/skills/azure-monitor-ingestion-java/SKILL.md
@@ -224,7 +224,7 @@ try {
 
 ## Querying Uploaded Logs
 
-Use [azure-monitor-query](../query/SKILL.md) to query ingested logs:
+Use [azure-monitor-query](../azure-monitor-query-java/SKILL.md) to query ingested logs:
 
 ```java
 // See azure-monitor-query skill for LogsQueryClient usage


### PR DESCRIPTION
Fixes broken link to `.github/plugins/azure-sdk-java/skills/azure-monitor-query-java/SKILL.md` in `.github/plugins/azure-sdk-java/skills/azure-monitor-ingestion-java/SKILL.md`



(Side-note: stumbled upon it while playing with https://github.com/rsn491/ctxlint)