### PR TITLE
Sync cloud-solution-architect skill with Azure Architecture Center

### DIFF
--- a/.github/skills/cloud-solution-architect/SKILL.md
+++ b/.github/skills/cloud-solution-architect/SKILL.md
@@ -14,8 +14,9 @@ Design well-architected, production-grade cloud systems following Azure Architec
 
 - **10 design principles** for Azure applications
 - **6 architecture styles** with selection guidance
-- **44 cloud design patterns** mapped to WAF pillars
+- **44 cloud design patterns** mapped to WAF pillars, with selection and composition guidance
 - **Technology choice frameworks** for compute, storage, data, messaging
+- **AI workload design** guidance for the five-layer application model
 - **Performance antipatterns** to avoid
 - **Architecture review workflow** for systematic design validation
 
@@ -62,79 +63,96 @@ Design well-architected, production-grade cloud systems following Azure Architec
 
 44 patterns organized by primary concern. WAF pillar mapping: **R**=Reliability, **S**=Security, **CO**=Cost Optimization, **OE**=Operational Excellence, **PE**=Performance Efficiency.
 
+### Selecting a Pattern
+
+Cloud workloads are vulnerable to the fallacies of distributed computing — assumptions like "the network is reliable," "latency is zero," and "bandwidth is infinite." These misconceptions produce flawed designs; patterns compensate for them.
+
+- **Choose a pattern by problem, not technology.** Start from a specific constraint or risk: a service that fails under load, a data store that can't keep up with reads, a dependency you can't fully trust.
+- **A pattern fits when its problem statement matches your challenge** and the trade-offs it introduces are ones you can accept in your workload.
+- **Every pattern has trade-offs,** and some affect other WAF pillars. Focus on why you choose a pattern, not just how to implement it.
+
 ### Messaging & Communication
 
 | Pattern | Summary | Pillars |
 |---------|---------|---------|
-| **Asynchronous Request-Reply** | Decouple request/response with polling or callbacks | R, PE |
-| **Claim Check** | Split large messages; store payload separately, pass reference | R, PE |
-| **Choreography** | Services coordinate via events without central orchestrator | R, OE |
-| **Competing Consumers** | Multiple consumers process messages from shared queue concurrently | R, PE |
-| **Messaging Bridge** | Connect incompatible messaging systems | R, OE |
-| **Pipes and Filters** | Decompose complex processing into reusable filter stages | R, OE |
-| **Priority Queue** | Prioritize requests so higher-priority work is processed first | R, PE |
-| **Publisher/Subscriber** | Decouple senders from receivers via topics/subscriptions | R, PE |
-| **Queue-Based Load Leveling** | Buffer requests with a queue to smooth intermittent loads | R, PE |
-| **Sequential Convoy** | Process related messages in order while allowing parallel groups | R, PE |
+| [Asynchronous Request-Reply](https://learn.microsoft.com/en-us/azure/architecture/patterns/asynchronous-request-reply) | Decouple request/response with polling or callbacks | PE |
+| [Claim Check](https://learn.microsoft.com/en-us/azure/architecture/patterns/claim-check) | Split large messages; store payload separately, pass reference | R, S, CO, PE |
+| [Choreography](https://learn.microsoft.com/en-us/azure/architecture/patterns/choreography) | Services coordinate via events without central orchestrator | OE, PE |
+| [Competing Consumers](https://learn.microsoft.com/en-us/azure/architecture/patterns/competing-consumers) | Multiple consumers process messages from shared queue concurrently | R, CO, PE |
+| [Messaging Bridge](https://learn.microsoft.com/en-us/azure/architecture/patterns/messaging-bridge) | Connect incompatible messaging systems | CO, OE |
+| [Pipes and Filters](https://learn.microsoft.com/en-us/azure/architecture/patterns/pipes-and-filters) | Decompose complex processing into reusable filter stages | R |
+| [Priority Queue](https://learn.microsoft.com/en-us/azure/architecture/patterns/priority-queue) | Prioritize requests so higher-priority work is processed first | R, PE |
+| [Publisher/Subscriber](https://learn.microsoft.com/en-us/azure/architecture/patterns/publisher-subscriber) | Decouple senders from receivers via topics/subscriptions | R, S, CO, OE, PE |
+| [Queue-Based Load Leveling](https://learn.microsoft.com/en-us/azure/architecture/patterns/queue-based-load-leveling) | Buffer requests with a queue to smooth intermittent loads | R, CO, PE |
+| [Sequential Convoy](https://learn.microsoft.com/en-us/azure/architecture/patterns/sequential-convoy) | Process related messages in order while allowing parallel groups | R |
 
 ### Reliability & Resilience
 
 | Pattern | Summary | Pillars |
 |---------|---------|---------|
-| **Bulkhead** | Isolate resources per workload to prevent cascading failure | R |
-| **Circuit Breaker** | Stop calling a failing service; fail fast to protect resources | R |
-| **Compensating Transaction** | Undo previously committed steps when a later step fails | R |
-| **Health Endpoint Monitoring** | Expose health checks for load balancers and orchestrators | R, OE |
-| **Leader Election** | Coordinate distributed instances by electing a leader | R |
-| **Retry** | Handle transient faults by retrying with exponential backoff | R |
-| **Saga** | Manage data consistency across microservices with compensating transactions | R |
-| **Scheduler Agent Supervisor** | Coordinate distributed actions with retry and failure handling | R |
+| [Bulkhead](https://learn.microsoft.com/en-us/azure/architecture/patterns/bulkhead) | Isolate resources per workload to prevent cascading failure | R, S, PE |
+| [Circuit Breaker](https://learn.microsoft.com/en-us/azure/architecture/patterns/circuit-breaker) | Stop calling a failing service; fail fast to protect resources | R, PE |
+| [Compensating Transaction](https://learn.microsoft.com/en-us/azure/architecture/patterns/compensating-transaction) | Undo previously committed steps when a later step fails | R |
+| [Health Endpoint Monitoring](https://learn.microsoft.com/en-us/azure/architecture/patterns/health-endpoint-monitoring) | Expose health checks for load balancers and orchestrators | R, OE, PE |
+| [Idempotent Consumer](https://learn.microsoft.com/en-us/azure/architecture/patterns/idempotent-consumer) | Handle duplicate message delivery so reprocessing has no additional effect | R |
+| [Leader Election](https://learn.microsoft.com/en-us/azure/architecture/patterns/leader-election) | Coordinate distributed instances by electing a leader | R |
+| [Retry](https://learn.microsoft.com/en-us/azure/architecture/patterns/retry) | Handle transient faults by retrying with exponential backoff | R |
+| [Saga](https://learn.microsoft.com/en-us/azure/architecture/patterns/saga) | Manage data consistency across microservices with compensating transactions | R |
+| [Scheduler Agent Supervisor](https://learn.microsoft.com/en-us/azure/architecture/patterns/scheduler-agent-supervisor) | Coordinate distributed actions with retry and failure handling | R, PE |
 
 ### Data Management
 
 | Pattern | Summary | Pillars |
 |---------|---------|---------|
-| **Cache-Aside** | Load data on demand into cache from data store | PE |
-| **CQRS** | Separate read and write models for independent scaling | PE, R |
-| **Event Sourcing** | Store state as append-only sequence of domain events | R, OE |
-| **Index Table** | Create indexes over frequently queried fields in data stores | PE |
-| **Materialized View** | Pre-compute views over data for efficient queries | PE |
-| **Sharding** | Distribute data across partitions for scale and performance | PE, R |
-| **Static Content Hosting** | Serve static content from cloud storage/CDN directly | PE, CO |
-| **Valet Key** | Grant clients limited direct access to storage resources | S, PE |
+| [Cache-Aside](https://learn.microsoft.com/en-us/azure/architecture/patterns/cache-aside) | Load data on demand into cache from data store | R, PE |
+| [CQRS](https://learn.microsoft.com/en-us/azure/architecture/patterns/cqrs) | Separate read and write models for independent scaling | PE |
+| [Event Sourcing](https://learn.microsoft.com/en-us/azure/architecture/patterns/event-sourcing) | Store state as append-only sequence of domain events | R, PE |
+| [Index Table](https://learn.microsoft.com/en-us/azure/architecture/patterns/index-table) | Create indexes over frequently queried fields in data stores | R, PE |
+| [Materialized View](https://learn.microsoft.com/en-us/azure/architecture/patterns/materialized-view) | Pre-compute views over data for efficient queries | PE |
+| [Sharding](https://learn.microsoft.com/en-us/azure/architecture/patterns/sharding) | Distribute data across partitions for scale and performance | R, CO |
+| [Static Content Hosting](https://learn.microsoft.com/en-us/azure/architecture/patterns/static-content-hosting) | Serve static content from cloud storage/CDN directly | CO |
+| [Valet Key](https://learn.microsoft.com/en-us/azure/architecture/patterns/valet-key) | Grant clients limited direct access to storage resources | S, CO, PE |
 
 ### Design & Structure
 
 | Pattern | Summary | Pillars |
 |---------|---------|---------|
-| **Ambassador** | Offload cross-cutting concerns to a helper sidecar proxy | OE |
-| **Anti-Corruption Layer** | Translate between new and legacy system models | OE, R |
-| **Backends for Frontends** | Create separate backends per frontend type (mobile, web, etc.) | OE, PE |
-| **Compute Resource Consolidation** | Combine multiple workloads into fewer compute instances | CO |
-| **External Configuration Store** | Externalize configuration from deployment packages | OE |
-| **Sidecar** | Deploy helper components alongside the main service | OE |
-| **Strangler Fig** | Incrementally migrate legacy systems by replacing pieces | OE, R |
+| [Ambassador](https://learn.microsoft.com/en-us/azure/architecture/patterns/ambassador) | Offload cross-cutting concerns to a helper sidecar proxy | R, S |
+| [Anti-Corruption Layer](https://learn.microsoft.com/en-us/azure/architecture/patterns/anti-corruption-layer) | Translate between new and legacy system models | OE |
+| [Backends for Frontends](https://learn.microsoft.com/en-us/azure/architecture/patterns/backends-for-frontends) | Create separate backends per frontend type (mobile, web, etc.) | R, S, PE |
+| [Compute Resource Consolidation](https://learn.microsoft.com/en-us/azure/architecture/patterns/compute-resource-consolidation) | Combine multiple workloads into fewer compute instances | CO, OE, PE |
+| [External Configuration Store](https://learn.microsoft.com/en-us/azure/architecture/patterns/external-configuration-store) | Externalize configuration from deployment packages | OE |
+| [Sidecar](https://learn.microsoft.com/en-us/azure/architecture/patterns/sidecar) | Deploy helper components alongside the main service | S, OE |
+| [Strangler Fig](https://learn.microsoft.com/en-us/azure/architecture/patterns/strangler-fig) | Incrementally migrate legacy systems by replacing pieces | R, CO, OE |
 
 ### Security & Access
 
 | Pattern | Summary | Pillars |
 |---------|---------|---------|
-| **Federated Identity** | Delegate authentication to an external identity provider | S |
-| **Gatekeeper** | Protect services using a dedicated broker that validates requests | S |
-| **Quarantine** | Isolate and validate external assets before allowing use | S |
-| **Rate Limiting** | Control consumption rate of resources by consumers | R, S |
-| **Throttling** | Control resource consumption to sustain SLAs under load | R, PE |
+| [Federated Identity](https://learn.microsoft.com/en-us/azure/architecture/patterns/federated-identity) | Delegate authentication to an external identity provider | R, S, PE |
+| [Gatekeeper](https://learn.microsoft.com/en-us/azure/architecture/patterns/gatekeeper) | Protect services using a dedicated broker that validates requests | S, PE |
+| [Quarantine](https://learn.microsoft.com/en-us/azure/architecture/patterns/quarantine) | Isolate and validate external assets before allowing use | S, OE |
+| [Rate Limiting](https://learn.microsoft.com/en-us/azure/architecture/patterns/rate-limiting-pattern) | Control consumption rate of resources by consumers | R |
+| [Throttling](https://learn.microsoft.com/en-us/azure/architecture/patterns/throttling) | Control resource consumption to sustain SLAs under load | R, S, CO, PE |
 
 ### Deployment & Scaling
 
 | Pattern | Summary | Pillars |
 |---------|---------|---------|
-| **Deployment Stamps** | Deploy multiple independent copies of application components | R, PE |
-| **Edge Workload Configuration** | Configure workloads differently across diverse edge devices | OE |
-| **Gateway Aggregation** | Aggregate multiple backend calls into a single client request | PE |
-| **Gateway Offloading** | Offload shared functionality (SSL, auth) to a gateway | OE, S |
-| **Gateway Routing** | Route requests to multiple backends using a single endpoint | OE |
-| **Geode** | Deploy backends to multiple regions for active-active serving | R, PE |
+| [Deployment Stamps](https://learn.microsoft.com/en-us/azure/architecture/patterns/deployment-stamp) | Deploy multiple independent copies of application components | OE, PE |
+| [Gateway Aggregation](https://learn.microsoft.com/en-us/azure/architecture/patterns/gateway-aggregation) | Aggregate multiple backend calls into a single client request | R, S, OE, PE |
+| [Gateway Offloading](https://learn.microsoft.com/en-us/azure/architecture/patterns/gateway-offloading) | Offload shared functionality (SSL, auth) to a gateway | R, S, CO, OE, PE |
+| [Gateway Routing](https://learn.microsoft.com/en-us/azure/architecture/patterns/gateway-routing) | Route requests to multiple backends using a single endpoint | R, OE, PE |
+| [Geode](https://learn.microsoft.com/en-us/azure/architecture/patterns/geodes) | Deploy backends to multiple regions for active-active serving | R, PE |
+
+### Combining Patterns
+
+Patterns are composable. A single pattern addresses one problem, but a workload usually faces several at once:
+
+- **Retry + Circuit Breaker** — retry transient faults, but stop retrying when a fault persists.
+- **Queue-Based Load Leveling + Competing Consumers** — buffer load with a queue, then scale out the processing of that load.
+- **Gateway Routing + Gateway Aggregation + Gateway Offloading** — layer all three behind a single gateway endpoint.
+- **Saga + Compensating Transaction** — maintain data consistency across services when a distributed operation fails partway through.
 
 See [Design Patterns Reference](./references/design-patterns.md) for detailed implementation guidance.
 
@@ -219,6 +237,29 @@ See [Mission-Critical Reference](./references/mission-critical.md) for detailed 
 
 ---
 
+## AI Workload Design
+
+AI workloads need the same pattern discipline as any distributed system, plus coordination approaches for nondeterministic, autonomous components. Design intelligent capabilities across five layers, each enforcing its own policies, identity, and caching:
+
+| Layer | Responsibility |
+|-------|----------------|
+| **Client** | User interface and client applications; keep this layer thin |
+| **Intelligence** | Routing, orchestration, and agent capabilities that coordinate AI operations |
+| **Inferencing** | Model loading, runtime invocation, input/output pre- and postprocessing |
+| **Knowledge** | Grounding data, retrieval services, and access policy enforcement for context |
+| **Tools** | Business APIs and action capabilities the intelligence layer can invoke |
+
+Key design considerations:
+
+- **Multi-layer caching** — cache results and answers, retrieved grounding snippets, and intermediate model outputs. Scope cache keys by tenant/user identity, policy context, model version, and prompt version. Risks: data leakage, stale data, privacy violations.
+- **Model routing** — route requests across models for availability or per-task quality. Use when the workload tolerates added variability and latency; avoid when deterministic behavior or fine-tuned models with narrow SLOs are required.
+- **Grounding data design** — externalize grounding data to a search index rather than querying source systems directly; chunk to fit context windows; iterate on chunking and embeddings based on observed query patterns.
+- **AI agent orchestration** — for multi-agent workloads, apply the dedicated [AI agent orchestration patterns](https://learn.microsoft.com/en-us/azure/architecture/ai-ml/guide/ai-agent-design-patterns).
+
+For full guidance, see [Well-Architected Framework guidance for AI workloads](https://learn.microsoft.com/azure/well-architected/ai/).
+
+---
+
 ## Well-Architected Framework (WAF) Pillars
 
 Every architecture decision should be evaluated against all five pillars:
@@ -269,7 +310,9 @@ Use the technology choices decision framework. Prefer managed services (PaaS) ov
 
 ### Step 4: Apply Design Patterns
 
-Select relevant patterns from the 44 cloud design patterns based on identified concerns.
+Select relevant patterns from the 44 cloud design patterns based on identified concerns. Choose by problem statement, not technology, and accept each pattern's trade-offs consciously.
+
+Perform [failure mode analysis](https://learn.microsoft.com/en-us/azure/architecture/resiliency/failure-mode-analysis/) on the resulting design: for each component, identify possible failure modes, their blast radius, and the detection and recovery response.
 
 ### Step 5: Address Cross-Cutting Concerns
 
@@ -277,6 +320,7 @@ Select relevant patterns from the 44 cloud design patterns based on identified c
 - **Monitoring** — Application Insights, Azure Monitor, Log Analytics
 - **Security** — Network segmentation, encryption at rest/in transit, Key Vault
 - **CI/CD** — GitHub Actions, Azure DevOps Pipelines, infrastructure as code
+- **AI workloads** — five-layer design (client, intelligence, inferencing, knowledge, tools), grounding data design, model routing trade-offs
 
 ### Step 6: Validate Against WAF Pillars
 
@@ -309,6 +353,9 @@ Use Architecture Decision Records (ADRs):
 - [Technology Choices Reference](./references/technology-choices.md) — Decision trees for Azure services
 - [Best Practices Reference](./references/best-practices.md) — Implementation guidance
 - [Mission-Critical Reference](./references/mission-critical.md) — High-availability design
+- [Design Principles Reference](./references/design-principles.md) — The ten design principles in depth
+- [Architecture Styles Reference](./references/architecture-styles.md) — Architecture style comparisons
+- [Performance Antipatterns Reference](./references/performance-antipatterns.md) — Detection and remediation
 
 ---
 

--- a/.github/skills/cloud-solution-architect/references/design-patterns.md
+++ b/.github/skills/cloud-solution-architect/references/design-patterns.md
@@ -8,7 +8,7 @@ A comprehensive reference of all 44 cloud design patterns from the Azure Archite
 
 ### Availability / Reliability
 
-Circuit Breaker · Compensating Transaction · Health Endpoint Monitoring · Leader Election · Queue-Based Load Leveling · Retry · Saga · Scheduler Agent Supervisor · Sequential Convoy · Bulkhead · Rate Limiting
+Circuit Breaker · Compensating Transaction · Health Endpoint Monitoring · Leader Election · Queue-Based Load Leveling · Retry · Saga · Scheduler Agent Supervisor · Sequential Convoy · Bulkhead · Rate Limiting · Idempotent Consumer
 
 ### Data Management
 
@@ -20,11 +20,11 @@ Ambassador · Anti-Corruption Layer · Backends for Frontends · Compute Resourc
 
 ### Messaging
 
-Asynchronous Request-Reply · Choreography · Claim Check · Competing Consumers · Messaging Bridge · Pipes and Filters · Priority Queue · Publisher/Subscriber · Queue-Based Load Leveling · Sequential Convoy
+Asynchronous Request-Reply · Choreography · Claim Check · Competing Consumers · Idempotent Consumer · Messaging Bridge · Pipes and Filters · Priority Queue · Publisher/Subscriber · Queue-Based Load Leveling · Sequential Convoy
 
 ### Performance / Scalability
 
-Cache-Aside · Geode · Throttling · Deployment Stamps · CQRS
+Cache-Aside · Geode · Throttling · Deployment Stamps · CQRS · Static Content Hosting
 
 ### Security
 
@@ -300,26 +300,7 @@ Gatekeeper · Quarantine · Valet Key · Federated Identity · Throttling
 
 ---
 
-### 15. Edge Workload Configuration
-
-**Centrally configure workloads that run at the edge, managing configuration drift and deployment consistency across heterogeneous edge devices.**
-
-**Problem:** Edge devices are numerous, heterogeneous, and often intermittently connected. Deploying and configuring workloads individually is error-prone. Configuration drift between devices causes inconsistent behavior and difficult debugging.
-
-**When to use:**
-
-- You manage a fleet of edge devices running the same workload with differing local parameters
-- Edge devices have intermittent connectivity and must operate independently
-- You need a central source of truth for configuration with local overrides
-- Audit and compliance require tracking which configuration each device is running
-
-**WAF Pillars:** Operational Excellence
-
-**Related patterns:** External Configuration Store, Sidecar, Ambassador
-
----
-
-### 16. Event Sourcing
+### 15. Event Sourcing
 
 **Use an append-only store to record the full series of events that describe actions taken on data in a domain.**
 
@@ -338,7 +319,7 @@ Gatekeeper · Quarantine · Valet Key · Federated Identity · Throttling
 
 ---
 
-### 17. External Configuration Store
+### 16. External Configuration Store
 
 **Move configuration information out of the application deployment package to a centralized location.**
 
@@ -353,11 +334,11 @@ Gatekeeper · Quarantine · Valet Key · Federated Identity · Throttling
 
 **WAF Pillars:** Operational Excellence
 
-**Related patterns:** Edge Workload Configuration, Sidecar
+**Related patterns:** Sidecar, Cache-Aside
 
 ---
 
-### 18. Federated Identity
+### 17. Federated Identity
 
 **Delegate authentication to an external identity provider.**
 
@@ -376,7 +357,7 @@ Gatekeeper · Quarantine · Valet Key · Federated Identity · Throttling
 
 ---
 
-### 19. Gatekeeper
+### 18. Gatekeeper
 
 **Protect applications and services by using a dedicated host instance that acts as a broker between clients and the application or service.**
 
@@ -395,7 +376,7 @@ Gatekeeper · Quarantine · Valet Key · Federated Identity · Throttling
 
 ---
 
-### 20. Gateway Aggregation
+### 19. Gateway Aggregation
 
 **Use a gateway to aggregate multiple individual requests into a single request.**
 
@@ -414,7 +395,7 @@ Gatekeeper · Quarantine · Valet Key · Federated Identity · Throttling
 
 ---
 
-### 21. Gateway Offloading
+### 20. Gateway Offloading
 
 **Offload shared or specialized service functionality to a gateway proxy.**
 
@@ -433,7 +414,7 @@ Gatekeeper · Quarantine · Valet Key · Federated Identity · Throttling
 
 ---
 
-### 22. Gateway Routing
+### 21. Gateway Routing
 
 **Route requests to multiple services using a single endpoint.**
 
@@ -452,7 +433,7 @@ Gatekeeper · Quarantine · Valet Key · Federated Identity · Throttling
 
 ---
 
-### 23. Geode
+### 22. Geode
 
 **Deploy backend services into a set of geographical nodes, each of which can service any client request in any region.**
 
@@ -471,7 +452,7 @@ Gatekeeper · Quarantine · Valet Key · Federated Identity · Throttling
 
 ---
 
-### 24. Health Endpoint Monitoring
+### 23. Health Endpoint Monitoring
 
 **Implement functional checks in an application that external tools can access through exposed endpoints at regular intervals.**
 
@@ -487,6 +468,32 @@ Gatekeeper · Quarantine · Valet Key · Federated Identity · Throttling
 **WAF Pillars:** Reliability, Operational Excellence, Performance Efficiency
 
 **Related patterns:** Circuit Breaker, Retry, Ambassador
+
+---
+
+### 24. Idempotent Consumer
+
+**Design message consumers so that processing the same message more than once has the same effect as processing it once.**
+
+**Problem:** Most message brokers guarantee at-least-once delivery. Duplicates arise from producer retries, redelivery after a missing acknowledgment, or consumer failures mid-processing. Exactly-once delivery is impractical to guarantee across a distributed system, so without duplicate resilience, reprocessing a message can create duplicate records, double-charge a customer, or have other unwanted effects.
+
+**When to use:**
+
+- You consume messages from a broker with at-least-once delivery (the default for most brokers)
+- Reprocessing a message produces incorrect results, such as duplicate financial transactions, duplicate resource creation, or repeated notifications
+- Multiple competing consumers process the same channel, making concurrent duplicate delivery likely
+- The same unit of work can run more than once outside messaging too — scheduled jobs that overlap, webhook endpoints, ETL and stream replays resumed from a checkpoint
+
+**Implementation notes:**
+
+- Prefer naturally idempotent operations first (upserts keyed on a business identifier, absolute-value writes); add a deduplication store only for operations that can't be made naturally idempotent
+- Key deduplication on a stable identifier that survives redelivery (Service Bus `MessageId`, CloudEvents `source` + `id`), not transport-level identifiers that change between duplicates
+- Commit the deduplication marker and the business side effects in the same transaction (the *inbox pattern*), and guard concurrent duplicates with a unique constraint at the data store
+- Retain deduplication records at least as long as the broker can redeliver the message, and propagate idempotency keys to downstream calls
+
+**WAF Pillars:** Reliability
+
+**Related patterns:** Competing Consumers, Retry, Queue-Based Load Leveling, Saga
 
 ---
 

--- a/.github/skills/cloud-solution-architect/references/design-patterns.md
+++ b/.github/skills/cloud-solution-architect/references/design-patterns.md
@@ -370,7 +370,7 @@ Gatekeeper · Quarantine · Valet Key · Federated Identity · Throttling
 - You want to limit the attack surface by isolating security checks from the trusted host
 - Compliance requires an explicit security boundary between public and private tiers
 
-**WAF Pillars:** Security
+**WAF Pillars:** Security, Performance Efficiency
 
 **Related patterns:** Valet Key, Gateway Routing, Gateway Offloading, Federated Identity
 

--- a/tests/scenarios/cloud-solution-architect/acceptance-criteria.md
+++ b/tests/scenarios/cloud-solution-architect/acceptance-criteria.md
@@ -409,7 +409,48 @@ We will use Cosmos DB for orders.
 
 ---
 
-## 7. Anti-Patterns Summary
+## 7. AI Workload Design
+
+### 7.1 ✅ CORRECT: AI Workload Designed Across the Five Layers with Grounding and Routing Decisions
+
+```markdown
+## AI Workload Design: Enterprise Assistant
+
+**Client**: Thin Teams/web front end; capabilities delegated to backend layers.
+
+**Intelligence**: Orchestrator with model routing — small fast model for
+simple queries, escalation to a larger model on low confidence.
+
+**Inferencing**: Model deployments with runtime invocation and prompt/
+completion pre- and postprocessing.
+
+**Knowledge**: Search index over approved documents; retrieval enforces
+per-user authorization; chunking iterated against observed queries.
+
+**Tools**: Ticketing and HR APIs behind standardized, policy-enforced
+interfaces.
+
+**Caching**: Grounded answers cached with keys scoped by user identity,
+model version, and prompt version; TTL by data freshness; no cross-user
+caching of private answers.
+
+**Routing decision**: Model routing tolerated for broad Q&A; single model
+pinned where deterministic behavior or narrow SLOs are required.
+```
+
+### 7.2 ❌ INCORRECT: AI Advice Without Layering, Grounding, or Routing Considerations
+
+```markdown
+## AI Design
+
+- Use GPT-4 for everything
+- Add a vector database
+- Fine-tune on your documents
+```
+
+---
+
+## 8. Anti-Patterns Summary
 
 | Anti-Pattern | Impact | Fix |
 |--------------|--------|-----|
@@ -422,7 +463,7 @@ We will use Cosmos DB for orders.
 
 ---
 
-## 8. Checklist for Architecture Review
+## 9. Checklist for Architecture Review
 
 - [ ] Architecture review maps to all 5 WAF pillars
 - [ ] Design patterns selected with problem context justification
@@ -434,3 +475,4 @@ We will use Cosmos DB for orders.
 - [ ] Health modeling strategy defined
 - [ ] Deployment strategy includes zero-downtime approach
 - [ ] Security follows Zero Trust model
+- [ ] AI workloads address the five layers, grounding, and model routing

--- a/tests/scenarios/cloud-solution-architect/scenarios.yaml
+++ b/tests/scenarios/cloud-solution-architect/scenarios.yaml
@@ -438,6 +438,7 @@ scenarios:
       - "decoupling"
       - "Event Hubs"
       - "Service Bus"
+      - "Idempotent Consumer"
     forbidden_patterns:
       - "api_key"
     tags:
@@ -480,7 +481,11 @@ scenarios:
         order processing workflow.
       - Use Event Hubs for high-volume analytical events and audit logging where
         throughput matters more than per-message guarantees.
-      - Implement idempotent event handlers — events may be delivered more than once.
+      - Apply the Idempotent Consumer pattern — at-least-once delivery means events
+        may be delivered more than once. Key deduplication on a stable message
+        identifier and record processed IDs atomically with business side effects,
+        so a redelivered event has no additional effect (duplicate deliveries are
+        skipped, not reprocessed).
       - Use the Saga pattern to coordinate the multi-step order workflow with
         compensating transactions for rollback on failure.
 
@@ -490,3 +495,63 @@ scenarios:
       creating a new subscription. Each service scales independently based on its
       own load patterns. Failures are isolated; if shipping is down, orders and
       payments continue processing.
+
+  # AI Workload Design
+  - name: ai_workload_design
+    prompt: |
+      We are building an enterprise AI assistant on Azure that answers
+      employee questions over internal documents and operational data.
+      Employees across regions will use it daily. We need to control
+      model costs, keep answers grounded in approved content, and avoid
+      stale or leaking cached answers. How should we design it?
+    expected_patterns:
+      - "Client"
+      - "Intelligence"
+      - "Inferencing"
+      - "Knowledge"
+      - "Tools"
+      - "grounding"
+      - "model routing"
+      - "caching"
+    forbidden_patterns:
+      - "api_key"
+    tags:
+      - ai-workload
+      - architecture
+    mock_response: |
+      ## Enterprise AI Assistant Workload Design
+
+      ### Five-Layer Application Model
+
+      **Client layer**: Thin Teams/web chat front end. Keep it thin —
+      delegate intelligence capabilities to the backend layers.
+
+      **Intelligence layer**: Orchestrates conversations and applies
+      model routing — a small fast model handles simple queries and
+      escalates to a larger model on low confidence, balancing cost
+      against answer quality.
+
+      **Inferencing layer**: Hosts the model deployments, handles runtime
+      invocation, and preprocesses prompts and postprocesses completions.
+
+      **Knowledge layer**: Grounding data in a search index over approved
+      internal documents. Retrieval enforces per-user and per-tenant
+      authorization. Chunking and embedding strategies are iterated
+      against observed query patterns.
+
+      **Tools layer**: Business APIs the assistant can invoke (ticketing,
+      HR lookups) behind standardized, policy-enforced interfaces.
+
+      ### Key Design Decisions
+
+      - **Multi-layer caching**: Cache grounded answers and retrieved
+        snippets. Scope cache keys by user identity, model version, and
+        prompt version; set TTLs by data freshness; never serve one
+        user's private answer to another. Caching reduces model
+        invocations, cutting cost and latency.
+      - **Model routing**: Apply model routing selectively — use it where
+        the workload tolerates added variability; pin a single model when
+        deterministic behavior or narrow SLOs are required.
+      - **Grounding over fine-tuning**: Start with retrieval grounding;
+        escalate to fine-tuning only when grounding cannot meet the
+        quality bar.


### PR DESCRIPTION
## What

Aligns the `cloud-solution-architect` skill with the current Azure Architecture Center content:

- Adds the **Idempotent Consumer** pattern (Reliability) to the catalog tables and the design patterns reference; the live catalog includes it and it is the key correctness pattern for at-least-once message delivery.
- Removes the retired **Edge Workload Configuration** pattern; it no longer appears in the catalog index and its page redirects to External Configuration Store. Cross-references updated accordingly.
- Corrects WAF pillar mappings across the pattern tables against the live catalog (for example, Ambassador maps to Reliability + Security, CQRS to Performance Efficiency only, Publisher/Subscriber to all five pillars).
- Links every pattern row to its learn.microsoft.com page for grounding and deep dives.
- Adds pattern selection guidance (choose by problem, not technology), a pattern composition section, an AI workload design section covering the five-layer application model (client / intelligence / inferencing / knowledge / tools), failure mode analysis in the architecture review workflow, and links for the three previously unlinked reference files.

## Why

The skill's pattern tables had drifted from the source catalog: one live pattern missing, one retired pattern still present, and many WAF pillar mappings out of date. The Architecture Center has also published AI workload design guidance that the skill did not yet reference.

## Validation performed

- Verified the live catalog index at https://learn.microsoft.com/en-us/azure/architecture/patterns/ (44 patterns) and transcribed pillar mappings and links from it.
- Verified the Edge Workload Configuration page redirects to External Configuration Store.
- Checks: 44 pattern links and 44 table rows in SKILL.md; design-patterns.md headings 1-44 in order with Idempotent Consumer at #24; zero remaining "Edge Workload" references; SKILL.md frontmatter unchanged.