### PR TITLE
chore: rename azure plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,6 +9,9 @@
     "version": "1.0.0",
     "pluginRoot": "./.github/plugins"
   },
+  "renames": {
+    "azure-skills": "azure"
+  },
   "plugins": [
     {
       "name": "deep-wiki",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,15 +22,29 @@
       "homepage": "https://github.com/microsoft/skills/tree/main/.github/plugins/deep-wiki",
       "repository": "https://github.com/microsoft/skills",
       "license": "MIT",
-      "keywords": ["wiki", "documentation", "mermaid", "architecture", "code-analysis"],
+      "keywords": [
+        "wiki",
+        "documentation",
+        "mermaid",
+        "architecture",
+        "code-analysis"
+      ],
       "category": "documentation",
-      "commands": ["./commands/"],
-      "skills": ["./skills/"],
-      "agents": ["./agents/wiki-architect.md", "./agents/wiki-researcher.md", "./agents/wiki-writer.md"],
+      "commands": [
+        "./commands/"
+      ],
+      "skills": [
+        "./skills/"
+      ],
+      "agents": [
+        "./agents/wiki-architect.md",
+        "./agents/wiki-researcher.md",
+        "./agents/wiki-writer.md"
+      ],
       "strict": true
     },
     {
-      "name": "azure-skills",
+      "name": "azure",
       "source": "./.github/plugins/azure-skills",
       "description": "Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from Claude Code.",
       "version": "1.0.0",
@@ -41,9 +55,18 @@
       "homepage": "https://github.com/microsoft/github-copilot-for-azure",
       "repository": "https://github.com/microsoft/github-copilot-for-azure",
       "license": "MIT",
-      "keywords": ["azure", "cloud", "infrastructure", "deployment", "microsoft", "devops"],
+      "keywords": [
+        "azure",
+        "cloud",
+        "infrastructure",
+        "deployment",
+        "microsoft",
+        "devops"
+      ],
       "category": "orchestration",
-      "skills": ["./skills/"]
+      "skills": [
+        "./skills/"
+      ]
     },
     {
       "name": "azure-sdk-python",
@@ -57,9 +80,19 @@
       "homepage": "https://github.com/microsoft/skills/tree/main/.github/plugins/azure-sdk-python",
       "repository": "https://github.com/microsoft/skills",
       "license": "MIT",
-      "keywords": ["azure", "python", "sdk", "ai", "storage", "identity", "monitoring"],
+      "keywords": [
+        "azure",
+        "python",
+        "sdk",
+        "ai",
+        "storage",
+        "identity",
+        "monitoring"
+      ],
       "category": "sdk",
-      "skills": ["./skills/"]
+      "skills": [
+        "./skills/"
+      ]
     },
     {
       "name": "azure-sdk-dotnet",
@@ -73,9 +106,18 @@
       "homepage": "https://github.com/microsoft/skills/tree/main/.github/plugins/azure-sdk-dotnet",
       "repository": "https://github.com/microsoft/skills",
       "license": "MIT",
-      "keywords": ["azure", "dotnet", "csharp", "sdk", "resource-manager", "identity"],
+      "keywords": [
+        "azure",
+        "dotnet",
+        "csharp",
+        "sdk",
+        "resource-manager",
+        "identity"
+      ],
       "category": "sdk",
-      "skills": ["./skills/"]
+      "skills": [
+        "./skills/"
+      ]
     },
     {
       "name": "azure-sdk-typescript",
@@ -89,9 +131,18 @@
       "homepage": "https://github.com/microsoft/skills/tree/main/.github/plugins/azure-sdk-typescript",
       "repository": "https://github.com/microsoft/skills",
       "license": "MIT",
-      "keywords": ["azure", "typescript", "nodejs", "sdk", "ai", "storage"],
+      "keywords": [
+        "azure",
+        "typescript",
+        "nodejs",
+        "sdk",
+        "ai",
+        "storage"
+      ],
       "category": "sdk",
-      "skills": ["./skills/"]
+      "skills": [
+        "./skills/"
+      ]
     },
     {
       "name": "azure-sdk-java",
@@ -105,9 +156,18 @@
       "homepage": "https://github.com/microsoft/skills/tree/main/.github/plugins/azure-sdk-java",
       "repository": "https://github.com/microsoft/skills",
       "license": "MIT",
-      "keywords": ["azure", "java", "sdk", "communication", "eventhub", "identity"],
+      "keywords": [
+        "azure",
+        "java",
+        "sdk",
+        "communication",
+        "eventhub",
+        "identity"
+      ],
       "category": "sdk",
-      "skills": ["./skills/"]
+      "skills": [
+        "./skills/"
+      ]
     },
     {
       "name": "azure-sdk-rust",
@@ -121,9 +181,18 @@
       "homepage": "https://github.com/microsoft/skills/tree/main/.github/plugins/azure-sdk-rust",
       "repository": "https://github.com/microsoft/skills",
       "license": "MIT",
-      "keywords": ["azure", "rust", "sdk", "keyvault", "storage", "cosmos"],
+      "keywords": [
+        "azure",
+        "rust",
+        "sdk",
+        "keyvault",
+        "storage",
+        "cosmos"
+      ],
       "category": "sdk",
-      "skills": ["./skills/"]
+      "skills": [
+        "./skills/"
+      ]
     }
   ]
 }

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -8,6 +8,9 @@
     "description": "Skills, agents, and plugins for AI coding agents working with Azure SDKs and Microsoft AI Foundry",
     "version": "1.0.0"
   },
+  "renames": {
+    "azure-skills": "azure"
+  },
   "plugins": [
     {
       "name": "deep-wiki",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -21,16 +21,27 @@
       "homepage": "https://github.com/microsoft/skills/tree/main/.github/plugins/deep-wiki",
       "repository": "https://github.com/microsoft/skills",
       "license": "MIT",
-      "keywords": ["wiki", "documentation", "mermaid", "architecture", "code-analysis"],
+      "keywords": [
+        "wiki",
+        "documentation",
+        "mermaid",
+        "architecture",
+        "code-analysis"
+      ],
       "category": "documentation",
-      "tags": ["deep-wiki", "diagrams", "citations", "codebase-understanding"],
+      "tags": [
+        "deep-wiki",
+        "diagrams",
+        "citations",
+        "codebase-understanding"
+      ],
       "commands": "commands/",
       "skills": "skills/",
       "agents": "agents/",
       "strict": true
     },
     {
-      "name": "azure-skills",
+      "name": "azure",
       "description": "Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from Claude Code.",
       "source": "./.github/plugins/azure-skills",
       "author": {
@@ -53,7 +64,15 @@
       "homepage": "https://github.com/microsoft/skills/tree/main/.github/plugins/azure-sdk-python",
       "repository": "https://github.com/microsoft/skills",
       "license": "MIT",
-      "keywords": ["azure", "python", "sdk", "ai", "storage", "identity", "monitoring"],
+      "keywords": [
+        "azure",
+        "python",
+        "sdk",
+        "ai",
+        "storage",
+        "identity",
+        "monitoring"
+      ],
       "category": "sdk",
       "skills": "skills/"
     },
@@ -69,7 +88,14 @@
       "homepage": "https://github.com/microsoft/skills/tree/main/.github/plugins/azure-sdk-dotnet",
       "repository": "https://github.com/microsoft/skills",
       "license": "MIT",
-      "keywords": ["azure", "dotnet", "csharp", "sdk", "resource-manager", "identity"],
+      "keywords": [
+        "azure",
+        "dotnet",
+        "csharp",
+        "sdk",
+        "resource-manager",
+        "identity"
+      ],
       "category": "sdk",
       "skills": "skills/"
     },
@@ -85,7 +111,14 @@
       "homepage": "https://github.com/microsoft/skills/tree/main/.github/plugins/azure-sdk-typescript",
       "repository": "https://github.com/microsoft/skills",
       "license": "MIT",
-      "keywords": ["azure", "typescript", "nodejs", "sdk", "ai", "storage"],
+      "keywords": [
+        "azure",
+        "typescript",
+        "nodejs",
+        "sdk",
+        "ai",
+        "storage"
+      ],
       "category": "sdk",
       "skills": "skills/"
     },
@@ -101,7 +134,14 @@
       "homepage": "https://github.com/microsoft/skills/tree/main/.github/plugins/azure-sdk-java",
       "repository": "https://github.com/microsoft/skills",
       "license": "MIT",
-      "keywords": ["azure", "java", "sdk", "communication", "eventhub", "identity"],
+      "keywords": [
+        "azure",
+        "java",
+        "sdk",
+        "communication",
+        "eventhub",
+        "identity"
+      ],
       "category": "sdk",
       "skills": "skills/"
     },
@@ -117,7 +157,14 @@
       "homepage": "https://github.com/microsoft/skills/tree/main/.github/plugins/azure-sdk-rust",
       "repository": "https://github.com/microsoft/skills",
       "license": "MIT",
-      "keywords": ["azure", "rust", "sdk", "keyvault", "storage", "cosmos"],
+      "keywords": [
+        "azure",
+        "rust",
+        "sdk",
+        "keyvault",
+        "storage",
+        "cosmos"
+      ],
       "category": "sdk",
       "skills": "skills/"
     },
@@ -133,7 +180,17 @@
       "homepage": "https://github.com/microsoft/skills/tree/main/.github/plugins/microsoft-foundry",
       "repository": "https://github.com/microsoft/skills",
       "license": "MIT",
-      "keywords": ["foundry", "azure-ai", "agents", "voice", "search", "rag", "content-safety", "model-deployment", "mcp"],
+      "keywords": [
+        "foundry",
+        "azure-ai",
+        "agents",
+        "voice",
+        "search",
+        "rag",
+        "content-safety",
+        "model-deployment",
+        "mcp"
+      ],
       "category": "ai",
       "skills": "skills/"
     }

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Coding agents like [Copilot CLI](https://github.com/features/copilot/cli) and [G
 | Resource | Description |
 |----------|-------------|
 | **[174 Skills](#skill-catalog)** | Domain-specific knowledge for Azure SDK and Foundry development |
-| **[Plugins](#plugins)** | Installable plugin packages (deep-wiki, azure-skills and more) |
+| **[Plugins](#plugins)** | Installable plugin packages (deep-wiki, azure and more) |
 | **[Custom Agents](#agents)** | Role-specific agents (backend, frontend, infrastructure, planner) |
 | **[AGENTS.md](AGENTS.md)** | Template for configuring agent behavior in your projects |
 | **[MCP Configs](#mcp-servers)** | Pre-configured servers for docs, GitHub, browser automation |
@@ -573,13 +573,13 @@ Plugins are installable packages containing curated sets of agents, commands, an
 # Inside Copilot CLI, run these slash commands:
 /plugin marketplace add microsoft/skills
 /plugin install deep-wiki@skills
-/plugin install azure-skills@skills
+/plugin install azure@skills
 ```
 
 | Plugin | Description | Commands |
 |--------|-------------|----------|
 | [deep-wiki](https://github.com/microsoft/skills/tree/main/.github/plugins/deep-wiki) | AI-powered wiki generator with Mermaid diagrams, source citations, onboarding guides, AGENTS.md, and llms.txt | `/deep-wiki:generate`, `/deep-wiki:crisp`, `/deep-wiki:catalogue`, `/deep-wiki:page`, `/deep-wiki:research`, `/deep-wiki:ask`, `/deep-wiki:onboard`, `/deep-wiki:agents`, `/deep-wiki:llms`, `/deep-wiki:changelog`, `/deep-wiki:ado`, `/deep-wiki:build`, `/deep-wiki:deploy` |
-| [azure-skills](https://github.com/microsoft/skills/tree/main/.github/plugins/azure-skills) | Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Includes 35 skills covering AI, storage, diagnostics, cost optimization, compliance, RBAC, the 3-step deployment workflow (`azure-prepare` → `azure-validate` → `azure-deploy`), and the language-agnostic `microsoft-foundry` orchestrator + 10 Foundry sub-skills (hosted agents, toolboxes, IQ knowledge bases, memory, observability, governance, more). | Skills-based (no slash commands) — auto-triggered by intent matching via `azure` and `foundry-mcp` MCP servers |
+| [azure](https://github.com/microsoft/skills/tree/main/.github/plugins/azure-skills) | Microsoft Azure MCP and Skills integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from your development environment. | Skills-based (no slash commands) — auto-triggered by intent matching via `azure` and `foundry-mcp` MCP servers |
 
 ---
 
@@ -703,7 +703,7 @@ The test harness implements iterative quality improvement patterns inspired by [
 
 ### Adding New Skills
 
-> **Note:** The `azure-skills` plugin (`.github/plugins/azure-skills/`) is copied from [microsoft/github-copilot-for-azure](https://github.com/microsoft/github-copilot-for-azure). Changes to that plugin should be made in the upstream repository rather than directly here.
+> **Note:** The `azure` plugin (`.github/plugins/azure-skills/`) is copied from [microsoft/github-copilot-for-azure](https://github.com/microsoft/github-copilot-for-azure). Changes to that plugin should be made in the upstream repository rather than directly here.
 
 New skills must follow the full workflow to ensure quality and discoverability:
 


### PR DESCRIPTION
Rename "azure-skills" to "azure" to match the exact plugin name.